### PR TITLE
Avoid singleton default options instance.

### DIFF
--- a/src/recaptcha.vue
+++ b/src/recaptcha.vue
@@ -15,7 +15,7 @@
       },
       options: {
         type: Object,
-        default: {}
+        default () => { return {}; }
       }
     },
     created() {


### PR DESCRIPTION
VueJs requires the use of a factory to provide default object values. Otherwise the default is a singleton, shared across all instances of the component.